### PR TITLE
Content type missing in post requests / new response format in createReceipt

### DIFF
--- a/lib7shifts/__init__.py
+++ b/lib7shifts/__init__.py
@@ -217,6 +217,7 @@ class APIClient7Shifts(object):
         headers['Authorization'] = f'Bearer {self.access_token}'
         headers['x-api-version'] = self.API_VERSION
         headers['accept'] = 'application/json'
+        headers['content-type'] = 'application/json'
         self.__connection_pool = urllib3.connectionpool.connection_from_url(
             self.BASE_URL, cert_reqs='CERT_REQUIRED', ca_certs=certifi.where(),
             headers=headers)

--- a/lib7shifts/receipts.py
+++ b/lib7shifts/receipts.py
@@ -111,7 +111,7 @@ def create_receipt(client, company_id, **kwargs):
     """
     response = client.create(
         ENDPOINT.format(company_id=company_id), body=kwargs)
-    return response['uuid']
+    return response['data']['uuid']
 
 
 def update_receipt(client, company_id, receipt_id, **kwargs):


### PR DESCRIPTION
@geradcoles thank you for your work on this! I have been using this lib for quite some time. With the migration to v2 there are two additional changes that you did not yet address:

1. POST requests now need content-type
2. response to createReceipt has a new format

please accept this pull request in order to make my fixes available to everyone.